### PR TITLE
Added query parameter mapping from route defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ swagger:
     api_gateway: false
 ```
 
-The full [configuration reference](docs/annotation-reference.md) for a comprehensive list of all values and defaults.
+The full [configuration reference](docs/configuration-reference.md) for a comprehensive list of all values and defaults.
 
 ### Routing
 
@@ -95,16 +95,19 @@ for details about swagger-php's syntax.
 ### Symfony Routes
 
 This bundle comes with an extra `\TimeInc\SwaggerBundle\Swagger\Annotation\Route` annotation that allows you to define
-a symfony route as a swagger endpoint.
+a symfony route as a swagger endpoint. using the annotation will set a swagger path for each method and add parameters
+for the path variables and any defaults as query strings.
 
 The annotation can be defined on a class or a method with the following properies:
 
-| Property | Context       | Default | Notes |
-|----------|---------------|---------|-------|
-| method   | CLASS         |         | The method name to inspect   |
-| route    | CLASS\|METHOD |         | The Symfony route to inspect |
-| returns  | CLASS\|METHOD | entity  | The response data type (collection\|entity) |
-| entity   | CLASS\|METHOD |         | The entity that is returned. If omitted, will be guessed based on controller name |
+| Property    | Context       | Default | Notes |
+|-------------|---------------|---------|-------|
+| method      | CLASS         |         | The method name to inspect   |
+| route       | CLASS\|METHOD |         | The Symfony route to inspect |
+| returns     | CLASS\|METHOD | entity  | The response data type (collection\|entity) |
+| entity      | CLASS\|METHOD |         | The entity that is returned. If omitted, will be guessed based on controller name |
+| queryParams | CLASS\|METHOD | []      | Any extra query parameters as Key/Value array of queryParameter/dataType |
+| headers     | CLASS\|METHOD | []      | Any extra header parameters as Key/Value array of headerName/dataType |
 
 > NOTE: If the entity is omitted, the bundle will search for an entity name of the same name as the controller in the 
   same bundle. For Example, the below example controller is `Acme\PetBundle\Controller\PetController`, so the bundle
@@ -140,7 +143,9 @@ class PetController
     /**
      * @Route(
      *     route="api_get_pet_owner",
-     *     entity="Acme\PetBundle\Entity\Owner"
+     *     entity="Acme\PetBundle\Entity\Owner",
+     *     headers={"X-TEST": "string"},
+     *     queryParams={"query": "string", "page": "integer"}
      * )
      */
     public function getOwnerAction()

--- a/src/Swagger/Annotation/Route.php
+++ b/src/Swagger/Annotation/Route.php
@@ -41,6 +41,16 @@ class Route
     public $entity_name;
 
     /**
+     * @var array
+     */
+    public $queryParams = [];
+
+    /**
+     * @var array
+     */
+    public $headers = [];
+
+    /**
      * @var string
      */
     public $returns = 'entity';

--- a/src/Swagger/Processor/RouteProcessor.php
+++ b/src/Swagger/Processor/RouteProcessor.php
@@ -132,9 +132,7 @@ class RouteProcessor
                     continue;
                 }
 
-                if (isset($path->parameters[$defaultKey])) {
-                    $path->parameters[$defaultKey]->default = $defaultValue;
-                } else {
+                if (!isset($path->parameters[$defaultKey])) {
                     $parameter = new Parameter(
                         [
                             'parameter' => $defaultKey,
@@ -145,6 +143,36 @@ class RouteProcessor
                         ]
                     );
                     $path->parameters[$defaultKey] = $parameter;
+                }
+            }
+
+            // add annotation query params
+            foreach ($options['queryParams'] as $queryKey => $queryDataType) {
+                if (!isset($path->parameters[$queryKey])) {
+                    $parameter = new Parameter(
+                        [
+                            'parameter' => $queryKey,
+                            'name' => $queryKey,
+                            'type' => $queryDataType,
+                            'in' => 'query',
+                        ]
+                    );
+                    $path->parameters[$queryKey] = $parameter;
+                }
+            }
+
+            // add annotation headers
+            foreach ($options['headers'] as $headerKey => $headerDataType) {
+                if (!isset($path->parameters[$headerKey])) {
+                    $parameter = new Parameter(
+                        [
+                            'parameter' => $headerKey,
+                            'name' => $headerKey,
+                            'type' => $headerDataType,
+                            'in' => 'header',
+                        ]
+                    );
+                    $path->parameters[$headerKey] = $parameter;
                 }
             }
 

--- a/tests/src/Swagger/Processor/RouteProcessorTest.php
+++ b/tests/src/Swagger/Processor/RouteProcessorTest.php
@@ -173,11 +173,13 @@ class RouteProcessorTest extends \PHPUnit_Framework_TestCase
                     /** @var Response $response */
                     if ($returns == Route::RETURNS_COLLECTION) {
                         $hasQueryParam = false;
-                        foreach ($path->parameters ?? [] as $parameter){
-                            if($parameter->parameter == 'name'){
-                                $this->assertEquals('query', $parameter->in);
-                                $this->assertEquals('test', $parameter->default);
-                                $hasQueryParam = true;
+                        if($path->parameters) {
+                            foreach ($path->parameters as $parameter) {
+                                if ($parameter->parameter == 'name') {
+                                    $this->assertEquals('query', $parameter->in);
+                                    $this->assertEquals('test', $parameter->default);
+                                    $hasQueryParam = true;
+                                }
                             }
                         }
                         if(!$hasQueryParam){

--- a/tests/src/Swagger/Processor/RouteProcessorTest.php
+++ b/tests/src/Swagger/Processor/RouteProcessorTest.php
@@ -53,8 +53,8 @@ class RouteProcessorTest extends \PHPUnit_Framework_TestCase
                              ->getMock();
 
         $this->routeCollection = new RouteCollection();
-        $this->routeCollection->add('get_foods', new SymfonyRoute('/foods', [], [], [], '', [], ['GET']));
-        $this->routeCollection->add('get_food', new SymfonyRoute('/food/{id}', [], [], [], '', [], ['GET']));
+        $this->routeCollection->add('get_foods', new SymfonyRoute('/foods', ['name' => null], [], [], '', [], ['GET']));
+        $this->routeCollection->add('get_food', new SymfonyRoute('/food/{id}', ['id' => 1], [], [], '', [], ['GET']));
         $this->routeCollection->add('post_food', new SymfonyRoute('/food', [], [], [], '', [], ['POST']));
         $this->routeCollection->add('put_food', new SymfonyRoute('/food/{id}', [], [], [], '', [], ['PUT']));
         $this->routeCollection->add('patch_food', new SymfonyRoute('/food/{id}', [], [], [], '', [], ['PATCH']));

--- a/tests/src/Swagger/Processor/RouteProcessorTest.php
+++ b/tests/src/Swagger/Processor/RouteProcessorTest.php
@@ -53,7 +53,7 @@ class RouteProcessorTest extends \PHPUnit_Framework_TestCase
                              ->getMock();
 
         $this->routeCollection = new RouteCollection();
-        $this->routeCollection->add('get_foods', new SymfonyRoute('/foods', ['name' => null], [], [], '', [], ['GET']));
+        $this->routeCollection->add('get_foods', new SymfonyRoute('/foods', ['name' => 'test'], [], [], '', [], ['GET']));
         $this->routeCollection->add('get_food', new SymfonyRoute('/food/{id}', ['id' => 1], [], [], '', [], ['GET']));
         $this->routeCollection->add('post_food', new SymfonyRoute('/food', [], [], [], '', [], ['POST']));
         $this->routeCollection->add('put_food', new SymfonyRoute('/food/{id}', [], [], [], '', [], ['PUT']));
@@ -68,10 +68,10 @@ class RouteProcessorTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                ['get' => ['get_foods', 'getFoods', Route::RETURNS_ENTITY]],
+                ['get' => ['get_foods', 'getFoods', Route::RETURNS_COLLECTION]],
             ],
             [
-                ['get' => ['get_food', 'getFood', Route::RETURNS_COLLECTION]],
+                ['get' => ['get_food', 'getFood', Route::RETURNS_ENTITY]],
             ],
             [
                 ['get' => ['get_food', 'getFood', Route::RETURNS_ENTITY]],
@@ -103,7 +103,7 @@ class RouteProcessorTest extends \PHPUnit_Framework_TestCase
     /**
      * Test the processor can be constructed.
      */
-    public function testContstructor()
+    public function testConstructor()
     {
         $this->router;
         $controllerOptions = [
@@ -171,6 +171,19 @@ class RouteProcessorTest extends \PHPUnit_Framework_TestCase
                     }
                     $this->assertCount(2, $path->get->responses);
                     /** @var Response $response */
+                    if ($returns == Route::RETURNS_COLLECTION) {
+                        $hasQueryParam = false;
+                        foreach ($path->parameters ?? [] as $parameter){
+                            if($parameter->parameter == 'name'){
+                                $this->assertEquals('query', $parameter->in);
+                                $this->assertEquals('test', $parameter->default);
+                                $hasQueryParam = true;
+                            }
+                        }
+                        if(!$hasQueryParam){
+                            $this->fail('Parameters for GET did not include query "name"');
+                        }
+                    }
                     foreach ($path->get->responses as $response) {
                         switch ($response->response) {
                             case 200:


### PR DESCRIPTION
Adding values to the route defaults will now add the relevant `query` swagger parameters:

```yaml
# routing.yml
acme_route:
    path: "/acme/demo/{something}"
    defaults: 
        _controller: "DecanterMediaBundle:ProtectedMedia:getProtectedMedia", 
        name: 'test' 
    methods: ['GET']
```