### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,10 @@
     ],
     "require": {
         "zircote/swagger-php": "~2.0",
-        "symfony/framework-bundle": ">=2.3",
-        "symfony/console": "~3.1"
+        "symfony/symfony": ">=2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
-        "symfony/browser-kit": "~3.1"
+        "phpunit/phpunit": "^4.8"
     },
     "autoload": {
         "psr-4": { "TimeInc\\SwaggerBundle\\": "src/" }


### PR DESCRIPTION
Hello,

having a "symfony/symfony": "2.8.*" dependency, it was impossible to me to install your bundle even if it allows framework starting at 2.3, due to the "symfony/console": "~3.1" dependency.