### PR TITLE
Added required items key to array parameters

### DIFF
--- a/src/Swagger/Processor/RouteProcessor.php
+++ b/src/Swagger/Processor/RouteProcessor.php
@@ -149,14 +149,16 @@ class RouteProcessor
             // add annotation query params
             foreach ($options['queryParams'] as $queryKey => $queryDataType) {
                 if (!isset($path->parameters[$queryKey])) {
-                    $parameter = new Parameter(
-                        [
-                            'parameter' => $queryKey,
-                            'name' => $queryKey,
-                            'type' => $queryDataType,
-                            'in' => 'query',
-                        ]
-                    );
+                    $parameterData = [
+                        'parameter' => $queryKey,
+                        'name' => $queryKey,
+                        'type' => $queryDataType,
+                        'in' => 'query',
+                    ];
+                    if ($queryDataType == 'array') {
+                        $parameterData['items'] = 'string';
+                    }
+                    $parameter = new Parameter($parameterData);
                     $path->parameters[$queryKey] = $parameter;
                 }
             }

--- a/tests/src/fixtures/TestApp/Component/Controller/TestController.php
+++ b/tests/src/fixtures/TestApp/Component/Controller/TestController.php
@@ -12,7 +12,12 @@ use TimeInc\SwaggerBundle\Swagger\Annotation\Route;
  * @Route(
  *     method="testAction",
  *     route="test_wine",
- *     entity="TimeInc\SwaggerBundle\Tests\fixtures\TestApp\TestBundle\Entity\Wine"
+ *     entity="TimeInc\SwaggerBundle\Tests\fixtures\TestApp\TestBundle\Entity\Wine",
+ *     queryParams={
+ *          "test_string": "string",
+ *          "test_array": "array",
+ *          "test_integer": "integer"
+ *     }
  * )
  */
 class TestController


### PR DESCRIPTION
An `array` query parameter defined in `Route::queryParams` requires an `items` key to be set. This sets a default (string).