### PR TITLE
make the SwaggerController compatible with Syfony 3.0 and lower

### DIFF
--- a/src/Controller/SwaggerController.php
+++ b/src/Controller/SwaggerController.php
@@ -3,7 +3,7 @@
 namespace TimeInc\SwaggerBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class SwaggerController extends Controller
 {
@@ -11,6 +11,6 @@ class SwaggerController extends Controller
     {
         $swagger = $this->get('swagger');
 
-        return new JsonResponse($swagger->json(), 200, [], true);
+        return new Response($swagger->json(), 200, ['Content-Type' => 'application/json']);
     }
 }

--- a/tests/src/Controller/SwaggerControllerTest.php
+++ b/tests/src/Controller/SwaggerControllerTest.php
@@ -23,5 +23,6 @@ class SwaggerControllerTest extends WebTestCase
         $this->assertEquals('application/json', $client->getResponse()->headers->get('Content-Type'));
 
         $content = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue(is_array($content));
     }
 }


### PR DESCRIPTION
In Symfony versions 3.0 and lower the swagger output gets json encoded twice when processed by the SwaggerController.

Fixes the issue #10 .
The tests are passing with Symfony 3.1, 3.0, 2.8 and 2.7
